### PR TITLE
Negative Multinomial aggiornata

### DIFF
--- a/gemact/config.py
+++ b/gemact/config.py
@@ -58,5 +58,7 @@ DIST_DICT = {
     'pareto2': 'distributions.Pareto2',
     'pareto1': 'distributions.Pareto1',
     'uniform': 'distributions.Uniform',
-    'multinomial': 'distributions.Multinomial'
+    'multinomial': 'distributions.Multinomial',
+    'dirichlet multinomial' : 'distributions.Dirichlet_Multinomial',
+    'negative multinomial' : 'distributions.NegMultinom'
 }

--- a/gemact/distributions.py
+++ b/gemact/distributions.py
@@ -6600,29 +6600,20 @@ class NegMultinom(_MultDiscreteDistribution):
         :return: random variates.
         :rtype: ``numpy.int`` or ``numpy.ndarray``
 
-        """
-        
+        """        
         prob = self.p
         beta = self.beta
-        #n = size
         
         random_state = hf.handle_random_state(random_state, logger)
         np.random.seed(random_state)
              
-        if isinstance(prob, np.ndarray) and len(prob.shape) == 1:
-            prob = np.tile(prob, (size, 1))
-            if np.isscalar(beta):
-                beta = np.full(size, beta)
-            else:
-                raise ValueError("The length of beta doesn't match with the size of prob.")      
+        prob = np.tile(prob, (size, 1))      
         k = prob.shape[1]
-                
-        probbeta = 1 - np.sum(prob, axis=1)
+        probbeta = 1 - np.sum(prob, axis=1)        
         prob = np.hstack((prob, probbeta[:, np.newaxis]))
         scale = 1 / probbeta - 1
         
-        G = np.array([stats.gamma.rvs(a=b, scale=p, size=1)[0] for b, p in zip(beta, scale)])
+        G = stats.gamma.rvs(a=beta, scale=scale, size=size)
         lambda_ = prob[:, :k] * (G / (1 - probbeta))[:, np.newaxis]
         
         return np.array([stats.poisson.rvs(mu=l) for l in lambda_])
-    

--- a/gemact/distributions.py
+++ b/gemact/distributions.py
@@ -6261,7 +6261,7 @@ class Multinomial(_MultDiscreteDistribution):
     
     @staticmethod
     def category():
-        return {'frequency'}
+        return {''}
     
     
     def cov(self):
@@ -6396,7 +6396,7 @@ class Dirichlet_Multinomial(_MultDiscreteDistribution):
     
     @staticmethod
     def category():
-        return {'frequency'}
+        return {''}
         
     def cov(self):
        """
@@ -6557,7 +6557,7 @@ class NegMultinom(_MultDiscreteDistribution):
     
     @staticmethod
     def category():
-        return {'frequency'}
+        return {''}
     
     def pmf(self, x):
         """

--- a/gemact/libraries.py
+++ b/gemact/libraries.py
@@ -14,3 +14,4 @@ import timeit
 from twiggy import quick_setup, log
 from itertools import groupby
 from scipy.special import gammaln
+import math as mt

--- a/gemact/libraries.py
+++ b/gemact/libraries.py
@@ -13,3 +13,4 @@ import time
 import timeit
 from twiggy import quick_setup, log
 from itertools import groupby
+from scipy.special import gammaln


### PR DESCRIPTION
Ciao a tutti,

ho aggiornato la Negative Multinomial seguendo l'implementazione di wikipedia "https://en.wikipedia.org/wiki/Negative_multinomial_distribution". In passato incontrai dei problemi sull'implementazione del metodo RVS (usare il metodo solito tramite cdf non mi risultava semplicissimo essendo una multivariata, ma magari mi sono arenato io ed esiste una formula una via semplice), che mi portò a cambiare il sistema di parametrizzazione seguendo quando implementato in R nel pacchetto MGLM, ora dovrei aver trovato una soluzione che dovrebbe funzionare:

Potremmo vedere la nostra distribuzione Negative Multinomial usando:
-Una binomiale negative per generare il numero totale
-Una multinomiale per ripartire i conteggi

In questo modo mi sembra proprio che i momenti della distribuzione simulata si parlino con quelli teorici, e l'implementazione è semplice. Fatemi sapere cosa ne pensate

Vi allego due semplici test, nel Test1 verifico che funzioni tutto a dovere.
Nel Test2 invece ho fatto qualche confronto con l'implementazione di MGLM. In effetti esiste qualche legame tra le due parametrizzazioni e si parlano quando il parametro di dispersione è 1 (formula non dispersa).

[Test 2- confronto con MGLM.txt](https://github.com/user-attachments/files/20027027/Test.2-.confronto.con.MGLM.txt)
[Test1.txt](https://github.com/user-attachments/files/20027028/Test1.txt)



