### PR TITLE
Fix/numpy2 compat

### DIFF
--- a/gemact/distributions.py
+++ b/gemact/distributions.py
@@ -4136,7 +4136,7 @@ class GenBeta:
 
         filter_one = (x == 0.0)
         if np.any(filter_one):
-            output[filter_one * (self.shape1 * self.shape3 < 1)] = np.infty
+            output[filter_one * (self.shape1 * self.shape3 < 1)] = np.inf
             output[filter_one * (self.shape1 * self.shape3 == 1)] = self.shape3 / special.beta(self.shape1,
                                                                                                      self.shape2)
 
@@ -4151,7 +4151,7 @@ class GenBeta:
 
         filter_three = (x > 0.0) * (x == self.scale)
         if np.any(filter_three):
-            output[filter_three * (self.shape2 < 1)] = np.infty
+            output[filter_three * (self.shape2 < 1)] = np.inf
             output[filter_three * (self.shape2 == 1)] = self.shape1 * self.shape3
 
         if len(output) == 1:
@@ -4376,7 +4376,7 @@ class GenBeta:
                                       1 - self._dist.cdf(u_))
 
         if 1 <= (- self.shape1 * self.shape3):
-            output = [np.infty] * v_shape
+            output = [np.inf] * v_shape
 
         if len(output) == 1:
             output = output.item()

--- a/gemact/distributions.py
+++ b/gemact/distributions.py
@@ -1268,7 +1268,7 @@ class ZTPoisson:
 
         temp = self._dist.pmf(x) / (1 - self.p0)
         x = np.array(x)
-        zeros = np.where(x == 0)[0]
+        zeros = np.where(np.atleast_1d(x == 0))[0]
         if zeros.size == 0:
             return temp
         else:
@@ -1518,7 +1518,7 @@ class ZMPoisson:
 
         temp = self._dist.pmf(x) * (1 - self.p0m) / (1 - self.p0)
         x = np.array(x)
-        zeros = np.where(x == 0)[0]
+        zeros = np.where(np.atleast_1d(x == 0))[0]
         if zeros.size == 0:
             return temp
         else:
@@ -1753,7 +1753,7 @@ class ZTBinom:
 
         temp = self._dist.pmf(x) / (1 - self.p0)
         x = np.array(x)
-        zeros = np.where(x == 0)[0]
+        zeros = np.where(np.atleast_1d(x == 0))[0]
         if zeros.size == 0:
             return temp
         else:
@@ -2620,7 +2620,7 @@ class ZTNegBinom:
         """
         temp = (self._dist.pmf(x)) / (1 - self.p0)
         x = np.array(x)
-        zeros = np.where(x == 0)[0]
+        zeros = np.where(np.atleast_1d(x == 0))[0]
         if zeros.size == 0:
             return temp
         else:
@@ -3142,7 +3142,7 @@ class ZMLogser:
         p_ = np.array(q)
         temp = self._dist.ppf((1 - self._dist.cdf(0)) * (p_ - self.p0m) / (1 - self.p0m) + self._dist.cdf(0))
 
-        zeros = np.where(p_ <= self.p0m)[0]
+        zeros = np.where(np.atleast_1d(p_ <= self.p0m))[0]
         if zeros.size == 0:
             return temp
         else:
@@ -3473,7 +3473,7 @@ class Exponential(_ContinuousDistribution):
 
         temp = -np.log(1 - q) / self.theta
 
-        zeros = np.where(((q >= 1.) & (q <= 0.)))[0]
+        zeros = np.where(np.atleast_1d(((q >= 1.) & (q <= 0.))))[0]
 
         if zeros.size == 0:
             return temp

--- a/gemact/helperfunctions.py
+++ b/gemact/helperfunctions.py
@@ -885,7 +885,7 @@ def censored_moment(n, d, c, dist):
 
     if (d == 0 and c == np.inf):
         output = dist.moment(n=n)
-    elif (n == 1) and (d > 0 or c < np.infty):
+    elif (n == 1) and (d > 0 or c < np.inf):
         output = dist.lev(v=c+d) - dist.lev(v=d)
     else:
         low = d

--- a/gemact/lossmodel.py
+++ b/gemact/lossmodel.py
@@ -356,7 +356,7 @@ class Layer:
         if self.category == 'xlrs':
             return True
         else:
-            if self.aggr_deductible > 0 or self.aggr_cover < np.infty:
+            if self.aggr_deductible > 0 or self.aggr_cover < np.inf:
                 return True
         return False
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 matplotlib==3.5.1
-numpy<2.0.0
+numpy>=1.21
 scipy>=1.10.0
 setuptools>=65.5.1
 Twiggy==0.5.1


### PR DESCRIPTION
Problem: GEMAct crashes on NumPy ≥ 2.0. 
Two removals bite: np.infty (gone in 2.0) and calling nonzero on 0-d arrays (now an error), the latter hitting scalar pmf/ppf calls on the zero-truncated/zero-modified distributions and Exponential.ppf. Currently masked by the numpy<2.0.0 pin, which forces a downgrade in any modern environment.
Changes: 5× np.infty → np.inf; 6× wrap the np.where condition in np.atleast_1d (as NumPy's own error message recommends), leaving the existing x.shape == () branches untouched; relax the pin.
Verification: full test suite passes on NumPy 2.5.1 (31 passed). 
Before the second fix, 6 tests failed; before the first, hard crash. 
Also verified on 1.26.4 — results bit-identical, so no behavior change for existing users.