### PR TITLE
Fix NumPy 2 incompatibility by bumping matplotlib pin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+
+.venv-ci/
+__pycache__/
+*.pyc

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-matplotlib==3.5.1
+matplotlib>=3.8.4
 numpy>=1.21
 scipy>=1.10.0
 setuptools>=65.5.1


### PR DESCRIPTION
Follow-up to #17. 
After the NumPy 2 compatibility fixes were merged, the CI (Git Actions) build on main started failing at the pytest step (exit code 2 — a collection error, before any test runs).
Cause: #17 relaxed the numpy<2.0.0 pin, so CI now resolves NumPy 2.x on Python 3.10. But requirements.txt still pinned matplotlib==3.5.1, which was based on NumPy 1.x. 
Under NumPy 2 the matplotlib import raises the "compiled using NumPy 1.x cannot be run in NumPy 2.x" error. 
Fix: Bump the pin to matplotlib>=3.8.4, the first release with wheels ABI-compatible with both NumPy 1.x and 2.x (still supports Python 3.10).
Local testing: New virtual env on Python 3.10 replicating the CI install steps; resolves to numpy 2.2.6 + matplotlib 3.10.9, and the full suite passes (31 passed).